### PR TITLE
extend windows on personal commitments and NTAs

### DIFF
--- a/src/functions/pollJournals/application/transfer-datasets.ts
+++ b/src/functions/pollJournals/application/transfer-datasets.ts
@@ -65,8 +65,8 @@ export const transferDatasets = async (startTime: Date): Promise<void> => {
     deployments,
   ] = await Promise.all([
     getTestSlots(connectionPool, examinerIds, journalStartDate, nextWorkingDay),
-    getPersonalCommitments(connectionPool, startDate, 14), // 14 days range
-    getNonTestActivities(connectionPool, startDate, nextWorkingDay),
+    getPersonalCommitments(connectionPool, journalStartDate, 14), // 14 days range
+    getNonTestActivities(connectionPool, journalStartDate, nextWorkingDay),
     getAdvanceTestSlots(connectionPool, startDate, nextWorkingDay, 14), // 14 days range
     getDeployments(connectionPool, startDate, 6), // 6 months range
   ]);


### PR DESCRIPTION
Extend the window of data retrieved for Personal Commitments and Non Test Activities to fix issue with personal commitments/non test activities in the past not being retrieved.