### PR TITLE
MES-3577 Increased the date window size for personal commitment query…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In a separate window
 run:
 
 ```shell
-npm run test:init
+npm run test:int
 ```
 
 If you get issues starting the integration tests due to ports already being bound, you can kill old instances of the test components by running:

--- a/src/functions/pollJournals/application/transfer-datasets.ts
+++ b/src/functions/pollJournals/application/transfer-datasets.ts
@@ -65,7 +65,7 @@ export const transferDatasets = async (startTime: Date): Promise<void> => {
     deployments,
   ] = await Promise.all([
     getTestSlots(connectionPool, examinerIds, journalStartDate, nextWorkingDay),
-    getPersonalCommitments(connectionPool, journalStartDate, 14), // 14 days range
+    getPersonalCommitments(connectionPool, journalStartDate, 20), // 20 days range
     getNonTestActivities(connectionPool, journalStartDate, nextWorkingDay),
     getAdvanceTestSlots(connectionPool, startDate, nextWorkingDay, 14), // 14 days range
     getDeployments(connectionPool, startDate, 6), // 6 months range


### PR DESCRIPTION
… to include today and future dates

# Description and relevant Jira numbers
Current logic around fetching  Personal Commitments is getting only yesterday's commitments due to recent changes - expanded the window size to include today and the worst-case scenario of 2 bank holidays after a weekend (Monday/Tuesday when current day is Friday)

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA